### PR TITLE
Add missing curly brace to CSS

### DIFF
--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -180,8 +180,9 @@ body {
 
 .about-us h3 {
     font-size: 30px;
+}
 
-.work .work-experience.inactive{
+.work .work-experience.inactive {
     display: none;
 }
 


### PR DESCRIPTION
This PR fixes the CSS. The missing curly brace meant that most of the CSS styling (all the styling beneath where the missing bracket was) was not being used. This makes our site presentable today!

![css](https://github.com/MAMV3x3/MLH-Fellowship-pe-portfolio-site/assets/71813760/9c3aef76-f101-4762-84c8-8ba0e837520c)
